### PR TITLE
abstract field render method to work around Chameleon bug/deficiency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*.egg-info
+*.pyc
+__pycache__
+*.swp
+.installed.cfg
+bin
+eggs
+develop-eggs
+env
+lib

--- a/wtforms_extras/__init__.py
+++ b/wtforms_extras/__init__.py
@@ -81,7 +81,13 @@ def render_field(form, fieldname, style='default', field_options=NO_VALUE,
             break
 
     if template:
-        return HTML(template(field=field, field_options=field_options,
+        def field_renderer(field, extra_options=None, **kwargs):
+            extra_args = extra_options if extra_options else {}
+            extra_args.update(kwargs)
+            return field(**extra_args)
+        return HTML(template(field_renderer=field_renderer,
+                             field=field,
+                             field_options=field_options,
                              errors=form.errors.get(fieldname, []),
                              **options))
     else:

--- a/wtforms_extras/templates/bootstrap/default.pt
+++ b/wtforms_extras/templates/bootstrap/default.pt
@@ -5,7 +5,7 @@
      tal:attributes="class klass">
   <label for="${field.id}" class="col-sm-2 control-label">${python: field.label.text}</label>
   <div class="col-sm-10">
-    <div tal:replace="structure python: field(id=field.id, class_='form-control', **field_options)" />
+    <div tal:replace="structure python: field_renderer(field, extra_options=field_options, id=field.id, class_='form-control')" />
     <tal:error tal:condition="errors">
       <span class="glyphicon glyphicon-remove form-control-feedback" aria-hidden="true"></span>
       <span id="inputError2Status" class="sr-only">(error)</span>

--- a/wtforms_extras/templates/default/default.pt
+++ b/wtforms_extras/templates/default/default.pt
@@ -11,6 +11,6 @@
     </ul>
   </div>
   <div class="placeholder"></div>
-  <div tal:replace="structure python: field(**field_options)" />
+  <div tal:replace="structure python: field_renderer(field, extra_options=field_options)" />
   <div class="clearfix visible-xs"></div>
 </div>

--- a/wtforms_extras/templates/foundation/default.pt
+++ b/wtforms_extras/templates/foundation/default.pt
@@ -1,10 +1,10 @@
 <div class="row" id="${field.id}-wrapper">
   <div class="large-12 columns">
     <label for="${field.id}" class="error" tal:condition="errors">${python: field.label.text}
-      <div tal:replace="structure python: field(id=field.id, **field_options)" />
+      <div tal:replace="structure python: field_renderer(field, extra_options=field_options, id=field.id)" />
     </label>
     <label for="${field.id}" tal:condition="not: errors">${python: field.label.text}
-      <div tal:replace="structure python: field(id=field.id, **field_options)" />
+      <div tal:replace="structure python: field_renderer(field, extra_options=field_options, id=field.id)" />
     </label>
     <small class="error" tal:condition="errors">
       <span tal:repeat="error errors">

--- a/wtforms_extras/templates/foundation/submitfield.pt
+++ b/wtforms_extras/templates/foundation/submitfield.pt
@@ -1,4 +1,4 @@
 <div class="row">
-  <div class="large-12 columns" tal:content="python: field(class_='button', **field_options)">
+  <div class="large-12 columns" tal:content="python: field_renderer(field, extra_options=field_options, class_='button')">
   </div>
 </div>


### PR DESCRIPTION
Chameleon (tested 2.15 and up to 2.24 w/ python 3.5 -- not sure the python version matters in this case though) does not seem to be able to parse (or handle gracefully) **kwarg parameters for python method calls, IE things like:

```
... python: field(field, id=field.id, **field_options) ...
```

would fail.

To reproduce this error:

```
virtualenv-3.5 ./env
./env/bin/python bootstrap.py
./bin/buildout -c buildout.cfg
./bin/test
```

The fix I'm proposing in this pull request just adds a method for field templates to use to skirt this issue by abstracting it out of the template itself.
